### PR TITLE
Server send "SERVER_STOPPED" message when turning off

### DIFF
--- a/src/main/java/fr/utc/onzzer/server/communication/ServerRequestHandler.java
+++ b/src/main/java/fr/utc/onzzer/server/communication/ServerRequestHandler.java
@@ -11,6 +11,7 @@ import fr.utc.onzzer.server.data.interfaces.DataTrackServices;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.Socket;
 import java.util.*;
 
 
@@ -23,6 +24,8 @@ public class ServerRequestHandler {
     public ServerRequestHandler(final Map<UserLite, ServerSocketManager> users, ServerController serverController) {
         this.users = users;
         this.serverController = serverController;
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> this.sendAllExclude(new SocketMessage(SocketMessagesTypes.SERVER_STOPPED, null), null)));
     }
 
     public void sendAllExclude(final SocketMessage message, final UUID excluded) {


### PR DESCRIPTION
~ Changed ServerRequestHandler constructor to launch a sleeping Thread that will send a "SERVER_STOPPED" message to all users when the server turns off